### PR TITLE
Fixed not closing when losing connection to sway

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -101,6 +101,8 @@ fn main() -> Res<()> {
                 *last = cur_focus;
                 cur_focus = ev.container.id;
             }
+        } else {
+            cleanup();
         }
     }
 }


### PR DESCRIPTION
Fixed a problem in sway-alttab where it will use 100% of the CPU, if you exited sway. 
If you then started sway up afterwards, it still consumes 100% of the CPU. 

It fails when the IPC fails to get the next event. It then exits with the cleanup code, there is already made. 